### PR TITLE
Feature/rpc error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,16 @@ Why opinionated? Unless told otherwise, will:
 * always publish messages as persistent
 * consumer-friendly request-reply-queue implementation
 * and more...
+
+**Running tests:**
+
+  Either use the available docker-compose to run on a container, OR
+
+  Install dependencies locally:
+  * Erlang
+  * RabbitMQ
+  * enable the management plugin
+  * download the delayed-messages plugin: https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases
+  * enable the delayed-messages plugin: https://github.com/rabbitmq/rabbitmq-delayed-message-exchange
+  
+Then run _mocha ./test_

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,7 +1,10 @@
+### NEXT
+* Return error response if RPC handler throws an error (instead of never responding)
+
 ## 3.1.0
 * Support of delayed messages using RabbitMQ extension
 
-## 3.0.0
+# 3.0.0
 * BREAKING CHANGES: 
   * change "createQueue" to "initQueue"
   * use queue-name from topology-configuration if no queue-name was provided in the options to "assertQueue" method  

--- a/test/delayed-messages.spec.js
+++ b/test/delayed-messages.spec.js
@@ -110,10 +110,7 @@ describe('Delayed messages', function() {
     });
 
     describe('delayed message, publish with delay', function () {
-
         let queueAdapter;
-        this.timeout(4000);
-        this.slow(4000);
 
         before('cleanup', cleanup);
 
@@ -129,7 +126,7 @@ describe('Delayed messages', function() {
 
         before('publishing', async function() {
             await queueAdapter.publishTo('test.no.delay.topic', 'hi there 2', {
-                delay: 2000,
+                delay: 500,
                 headers: {
                     'x-what': 'bar'
                 },
@@ -146,7 +143,7 @@ describe('Delayed messages', function() {
                 } catch (err) {
                     done(err);
                 }
-            }, 1700);
+            }, 300);
         });
 
         it('should receive the message after delay', function(done) {
@@ -160,7 +157,7 @@ describe('Delayed messages', function() {
                     expect(firstCallArg.message).to.equal('hi there 2');
                     expect(firstCallArg).to.have.property('headers');
                     expect(firstCallArg.headers).to.deep.equal({
-                        'x-delay': 2000,
+                        'x-delay': 500,
                         'x-what': 'bar'
                     })
                     done();

--- a/test/messaging-topic.spec.js
+++ b/test/messaging-topic.spec.js
@@ -52,7 +52,7 @@ describe('Messaging with broker', function () {
                 } catch (err) {
                     done(err);
                 }
-            }, 2000);
+            }, 200);
         });
         it('should receive the others, once acked (finished)', function (done) {
             const handleIncomingMessages = sinon.spy(message => {
@@ -69,7 +69,7 @@ describe('Messaging with broker', function () {
                 } catch (err) {
                     done(err);
                 }
-            }, 1000);
+            }, 200);
             finishMessageEvents.emit('go');
         });
     })

--- a/test/request-reply.spec.js
+++ b/test/request-reply.spec.js
@@ -5,8 +5,11 @@ const url = 'amqp://localhost';
 const common = require('./common');
 
 describe('request-reply should: ', function () {
-    it('send and receive via direct reply-to queue', async function () {
-        let broker = new Broker({
+    let server;
+    let broker;
+
+    beforeEach(async function () {
+        broker = new Broker({
             url,
             queues: {
                 testReplyTo: {
@@ -15,114 +18,71 @@ describe('request-reply should: ', function () {
                 }
             }
         });
-        try {
-            let serverReceived;
-            let server = broker.initQueue('testReplyTo');
-            console.log(`======================================= server: consuming from test-reply-to =======================================`);
-            await server.consume(async (data, props) => {
-                console.log(`======================================= server: received message =======================================`);
-                serverReceived = JSON.parse(data);
-                should.exist(props.replyTo);
-                return { ok: 1 };
-            });
 
+        server = broker.initQueue('testReplyTo');
+    });
 
-            let client = broker.initQueue('testReplyTo');
-            console.log(`======================================= client: PUBLISHING to test-reply-to =======================================`);
-            let response = await client.publish({ the: 'entity' });
+    afterEach(async function () {
+        await common.cleanup(broker, [], 'test-reply-to');
+    });
 
-            should.exist(serverReceived, `message was not received`);
-            serverReceived.should.deep.equal({ the: 'entity' });
-            response.should.deep.equal({ ok: 1 });
-            console.log(`=============================== SUCCESS ===============================`);
-        } finally {
-            await common.cleanup(broker, [], 'test-reply-to');
-        }
+    it('send and receive via direct reply-to queue', async function () {
+        let serverReceived;
+        console.log(`======================================= server: consuming from test-reply-to =======================================`);
+        await server.consume(async (data, props) => {
+            console.log(`======================================= server: received message =======================================`);
+            serverReceived = JSON.parse(data);
+            should.exist(props.replyTo);
+            return { ok: 1 };
+        });
+
+        let client = broker.initQueue('testReplyTo');
+        console.log(`======================================= client: PUBLISHING to test-reply-to =======================================`);
+        let response = await client.publish({ the: 'entity' });
+
+        should.exist(serverReceived, `message was not received`);
+        serverReceived.should.deep.equal({ the: 'entity' });
+        response.should.deep.equal({ ok: 1 });
+        console.log(`=============================== SUCCESS ===============================`);
     });
 
     it('publish multiple requests in parallel from the same queue wrapper', async function () {
-        let broker = new Broker({
-            url,
-            queues: {
-                testReplyTo: {
-                    name: 'test-reply-to',
-                    requestReply: true
-                }
-            }
+        await server.consume(async (data, props) => {
+            return { ok: 1 };
         });
-        try {
-            let server = broker.initQueue('testReplyTo');
-            await server.consume(async (data, props) => {
-                return { ok: 1 };
-            });
 
-            let client = broker.initQueue('testReplyTo');
-            await Promise.map(new Array(10).fill(1), async x => {
-                let response = await client.publish({ the: 'entity' });
-                response.should.deep.equal({ ok: 1 });
-            });
-        } finally {
-            await common.cleanup(broker, [], 'test-reply-to');
-        }
+        let client = broker.initQueue('testReplyTo');
+        await Promise.map(new Array(10).fill(1), async x => {
+            let response = await client.publish({ the: 'entity' });
+            response.should.deep.equal({ ok: 1 });
+        });
     });
 
     it('send and receive via direct reply-to queue without response', async function () {
-        let broker = new Broker({
-            url,
-            queues: {
-                testReplyTo: {
-                    name: 'test-reply-to',
-                    requestReply: true
-                }
-            }
+        let serverReceived;
+        await server.consume(async (data, props) => {
+            await Promise.delay(50);
+            serverReceived = JSON.parse(data);
         });
-        try {
-            let serverReceived;
-            let server = broker.initQueue('testReplyTo');
-            await server.consume(async (data, props) => {
-                await Promise.delay(50);
-                serverReceived = JSON.parse(data);
-            });
 
-            let client = broker.initQueue('testReplyTo');
-            let response = await client.publish({ the: 'entity' });
+        let client = broker.initQueue('testReplyTo');
+        let response = await client.publish({ the: 'entity' });
 
-            should.exist(serverReceived, `message was not received`);
-            serverReceived.should.deep.equal({ the: 'entity' });
+        should.exist(serverReceived, `message was not received`);
+        serverReceived.should.deep.equal({ the: 'entity' });
 
-            should.not.exist(response);
-        } finally {
-            await common.cleanup(broker, [], 'test-reply-to');
-        }
+        should.not.exist(response);
     });
 
     it('return error to client when server fails to process request', async function () {
-        let broker = new Broker({
-            url,
-            queues: {
-                testReplyTo: {
-                    name: 'test-reply-to',
-                    requestReply: true
-                }
-            }
+        await server.consume(async (data, props) => {
+            throw new Error('mock error from test')
         });
-        try {
-            let server = broker.initQueue('testReplyTo');
-            console.log(`======================================= server: consuming from test-reply-to =======================================`);
-            await server.consume(async (data, props) => {
-                console.log(`======================================= server: received message - throwing error =======================================`);
-                throw new Error('mock error from test')
-            });
 
-            let client = broker.initQueue('testReplyTo');
-            console.log(`======================================= client: PUBLISHING to test-reply-to =======================================`);
-            let response = await client.publish({ the: 'entity' });
-            console.log(`========== client: received response: ${JSON.stringify(response, null, 2)} ==========`);
+        let client = broker.initQueue('testReplyTo');
+        let response = await client.publish({ the: 'entity' });
 
-            should.exist(response.error);
-            should.exist(response.error.message);
-        } finally {
-            await common.cleanup(broker, [], 'test-reply-to');
-        }
+        should.exist(response.error);
+        should.exist(response.error.message);
     });
 });

--- a/test/request-reply.spec.js
+++ b/test/request-reply.spec.js
@@ -61,7 +61,6 @@ describe('request-reply should: ', function () {
     it('send and receive via direct reply-to queue without response', async function () {
         let serverReceived;
         await server.consume(async (data, props) => {
-            await Promise.delay(50);
             serverReceived = JSON.parse(data);
         });
 


### PR DESCRIPTION
this is a small patch to protect consumers from unexpected errors in request-reply queues. I changed some of your timeouts to decrease the execution time of the tests, which was very long.